### PR TITLE
OP-21549-AgentPortIssue: AgentPort changed from 9001 to 443 for new a…

### DIFF
--- a/app/server/config.go
+++ b/app/server/config.go
@@ -94,7 +94,7 @@ func LoadConfig(f io.Reader) (*ControllerConfig, error) {
 	}
 
 	if config.AgentListenPort == 0 {
-		config.AgentListenPort = 9001
+		config.AgentListenPort = 443
 	}
 	if config.AgentAdvertisePort == 0 {
 		config.AgentAdvertisePort = config.AgentListenPort


### PR DESCRIPTION
https://devopsmx.atlassian.net/browse/OP-21931

AgentListenPort     changed from 9001 to  443  because of new agent controller changes (jwt token )  for ingress  required port is   443
